### PR TITLE
Rollback if exiting with errors.

### DIFF
--- a/bin/workflow-wrapper.pl
+++ b/bin/workflow-wrapper.pl
@@ -113,6 +113,8 @@ sub print_exit_message {
 sub exit_wrapper {
     my ($message, $error) = @_;
 
+    rollback();
+
     if ($error) {
         print STDERR $error, "\n";
     }


### PR DESCRIPTION
The specific motivation for this change is to improve handling of allocations.  When an allocation is created, it records a change in UR.  Upon `rollback()` it will remove that allocation (and any other external changes that were logged) to return the system to a consistent state.  Hopefully this will help prevent "orphaned" allocations!

This could have negative side-effects if something was relying on data being left in place upon failure.
